### PR TITLE
Use phusion base image; support SSL and context-path via environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,11 @@
-FROM ubuntu:14.04
-#CMDBUILD	docker build -t ulikoenig/subsonic_patched https://raw.githubusercontent.com/ulikoenig/subsonic-patched/master/Dockerfile
-#CMDRUN		docker run -d --net=host -p 4040:4040 -p 9412:9412 -v /var/lib/subsonic:/data:rw -v /mnt/harddrive/Medien:/Medien:ro  ulikoenig/subsonic_patched
+FROM phusion/baseimage:0.9.18
 
-MAINTAINER Uli König <docker@ulikoenig.de.nospam> (@u98)
+MAINTAINER Vedran Vekić <inti.pacha@no.gmail.spam> (@u98)
 
 ENV	JAVA_HOME /usr/lib/jvm/java-8-oracle
 
-ENV	LANG	de_DE.UTF-8
-ENV	LC_ALL	de_DE.UTF-8
-ENV	LANGUAGE	de_DE
-
 RUN	apt-get update && \
 #Flac, Lame, FFMPEG, Oracle Java JDK
-	apt-get install -y language-pack-de && \
-	update-locale LANG=de_DE.UTF-8 && \
-	update-locale LANGUAGE=de_DE && \
-	locale-gen && \
 	apt-get install -y software-properties-common python-software-properties flac lame && \
 	add-apt-repository -y ppa:mc3man/trusty-media && \
 	echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
@@ -46,18 +36,10 @@ RUN	mv /var/subsonic /var/subsonic.default && \
 # Don't fork to the background
 RUN	sed -i "s/ > \${LOG} 2>&1 &//" /usr/share/subsonic/subsonic.sh 
 
-#RUN	sed -i "17d" /etc/default/subsonic && \
-#	sed -i "i1SUBSONIC_ARGS=\"--port=4040 --https-port=4443 --max-memory=200\"" /etc/default/subsonic
-
-VOLUME	["/data"]
-VOLUME	["/Media"]
+VOLUME	/data /media
 EXPOSE	4040
 EXPOSE	9412
 
-ADD	start.sh /start.sh
-
-#ADD	unionfs.sh /unionfs.sh 
-#RUN	sed -i "3i/unionfs.sh" /start.sh
-
-RUN	chmod a+x /start.sh 
-CMD	["/start.sh"]
+RUN mkdir /etc/service/subsonic
+ADD	start.sh /etc/service/subsonic/run
+RUN	chmod a+x /etc/service/subsonic/run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM phusion/baseimage:0.9.18
 
-MAINTAINER Vedran Vekić <inti.pacha@no.gmail.spam> (@u98)
+MAINTAINER Uli König <docker@ulikoenig.de.nospam> (@u98)
 
 ENV	JAVA_HOME /usr/lib/jvm/java-8-oracle
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ docker build -t ulikoenig/subsonic-patch https://raw.githubusercontent.com/uliko
 ## Run Container
 
 ```
-$ docker run -d --net=host -p 4040:4040 -p 9412:9412 -v /var/lib/subsonic:/data:rw -v /mnt/harddrive/Medien:/Medien:ro  ulikoenig/subsonic-patch
+$ docker run -d --net=host -p 4040:4040 -p 4050:4050 -p 9412:9412 -e SSL=yes -v /var/lib/subsonic:/data -v /mnt/harddrive/Medien:/media:ro  ulikoenig/subsonic_patched
 ```
 I used
 ``` /var/lib/subsonic ```
@@ -26,9 +26,6 @@ My media is stored in
 Please change this paths how you like it.
 
 The Parameter ``` "--net=host" ``` is important to give subsonic access to the real external IP. Without this, Sonos support will not work, even if ports are open, because subsonic tells Sonos to make calls to 172.xx.xx.xx IP-adresses.
-
-The Parameter ``` "--e LOCALIP=172.1.2.3" ``` can be used to set the IP manually, when the docker container is started.
-
 
 ## Finally:
 

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,4 @@
-#!/bin/sh
-if [ -z "$LOCALIP" ]; then
-	LOCALIP=`LC_ALL="en" ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | grep -v '172.'`
-fi
-
+#!/bin/bash
 echo "127.0.0.1 subsonic.org" >> /etc/hosts
 set -e
 
@@ -15,14 +11,18 @@ ln -s "$(which ffmpeg)" && \
 ln -s "$(which flac)" && \
 ln -s "$(which lame)"
 
+# enable/disable ssl based on env variable set from docker container run command
+if [[ "$SSL" = "yes" ]]; then
+	echo "Enabling SSL"
+	port="--https-port=4050"
+elif [[ "$SSL" = "no" ]]; then
+	echo "Disabling SSL"
+	port="--port=4040"
+ fi
 
+ # if context path not defined then set to empty string (default root context)
+ if [[ -z "${CONTEXT_PATH}" ]]; then
+	CONTEXT_PATH="/"
+ fi
 
-
-/usr/share/subsonic/subsonic.sh --host=$LOCALIP --max-memory=1024   & > /dev/null
-
-#do not exit container
-while true
-do
-	sleep 1000
-done
-
+/usr/share/subsonic/subsonic.sh ${port} --context-path=${CONTEXT_PATH} --default-music-folder=/media --max-memory=1024


### PR DESCRIPTION
I've converted to phusion/baseimage for efficiency and reliability. Also added support to enable SSL and customize context-path. The process is now run as a service via runit.
For non-german users' sake, I've removed DE locale.

Feel free to reject, and I will maintain my fork.
